### PR TITLE
test関数内でtestフェーズ後にtrainフェーズに戻す

### DIFF
--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -200,7 +200,13 @@ class network {
   }
 
   std::vector<tensor_t> fprop(const std::vector<tensor_t> &in) {
-    return net_.forward(in);
+    auto res = net_.forward(in);
+    /*std::cout << "res: ";
+    for (int i = 0; i < res[0][0].size(); ++i) {
+      std::cout << res[0][0][i] << " ";
+    }
+    std::cout << "\n";*/
+    return res;
   }
 
   /**
@@ -461,10 +467,20 @@ class network {
       const label_t predicted = fprop_max_index(in[i]);
       const label_t actual    = t[i];
 
+      // const vec_t prediction = predict(in[i]);
+      // std::cout << "prediction: "; 
+      // for (int i = 0; i < prediction.size(); ++i){
+      //   std::cout << prediction[i] << " ";
+      // }
+      // std::cout << "\n";
+
+      // std::cout << "pred:" << predicted << "actual:" << actual << std::endl;
+
       if (predicted == actual) test_result.num_success++;
       test_result.num_total++;
       test_result.confusion_matrix[predicted][actual]++;
     }
+    set_netphase(net_phase::train);  // train phaseに戻す
     return test_result;
   }
 

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -200,13 +200,7 @@ class network {
   }
 
   std::vector<tensor_t> fprop(const std::vector<tensor_t> &in) {
-    auto res = net_.forward(in);
-    /*std::cout << "res: ";
-    for (int i = 0; i < res[0][0].size(); ++i) {
-      std::cout << res[0][0][i] << " ";
-    }
-    std::cout << "\n";*/
-    return res;
+    return net_.forward(in);
   }
 
   /**
@@ -466,7 +460,7 @@ class network {
     for (size_t i = 0; i < in.size(); i++) {
       const label_t predicted = fprop_max_index(in[i]);
       const label_t actual    = t[i];
-      
+
       if (predicted == actual) test_result.num_success++;
       test_result.num_total++;
       test_result.confusion_matrix[predicted][actual]++;

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -466,21 +466,12 @@ class network {
     for (size_t i = 0; i < in.size(); i++) {
       const label_t predicted = fprop_max_index(in[i]);
       const label_t actual    = t[i];
-
-      // const vec_t prediction = predict(in[i]);
-      // std::cout << "prediction: "; 
-      // for (int i = 0; i < prediction.size(); ++i){
-      //   std::cout << prediction[i] << " ";
-      // }
-      // std::cout << "\n";
-
-      // std::cout << "pred:" << predicted << "actual:" << actual << std::endl;
-
+      
       if (predicted == actual) test_result.num_success++;
       test_result.num_total++;
       test_result.confusion_matrix[predicted][actual]++;
     }
-    set_netphase(net_phase::train);  // train phaseに戻す
+    set_netphase(net_phase::train);  // push back to train phase
     return test_result;
   }
 


### PR DESCRIPTION
### 背景
エポック終了時のcallback関数などでtestが呼ばれる場合、フェーズがtestのままで次のエポックが始まってしまうということになっていた。

batch normalization以外の層はphaseがtrainでもtestでも変わらなかったので何もエラーは起きていなかったが、phaseによって処理が変わってしまう層を使おうとするとエラーになる。

### 変更点
test関数の中で最後phaseをtrainに戻す